### PR TITLE
Don't fail when listing dir content that is ignored

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -23,6 +23,8 @@ import "fmt"
 
 var defaultTree tree // lazy init
 
+type DoNotWatchFn func(string) bool
+
 func lazyInitDefaultTree() (err error) {
 	if defaultTree != nil {
 		// already initialized
@@ -96,7 +98,7 @@ func Watch(path string, c chan<- EventInfo, events ...Event) error {
 // doNotWatch. Given a path as argument doNotWatch should return true if the
 // file or directory should not be watched.
 func WatchWithFilter(path string, c chan<- EventInfo,
-	doNotWatch func(string) bool, events ...Event) error {
+	doNotWatch DoNotWatchFn, events ...Event) error {
 	if err := lazyInitDefaultTree(); err != nil {
 		return err
 	}

--- a/testing_test.go
+++ b/testing_test.go
@@ -946,11 +946,11 @@ func (n *N) ExpectNotifyEvents(cases []NCase, all Chans) {
 func (n *N) Walk(fn walkFunc) {
 	switch t := n.tree.(type) {
 	case *recursiveTree:
-		if err := t.root.Walk("", fn); err != nil {
+		if err := t.root.Walk("", fn, nil); err != nil {
 			n.w.Fatal(err)
 		}
 	case *nonrecursiveTree:
-		if err := t.root.Walk("", fn); err != nil {
+		if err := t.root.Walk("", fn, nil); err != nil {
 			n.w.Fatal(err)
 		}
 	default:

--- a/tree.go
+++ b/tree.go
@@ -7,7 +7,7 @@ package notify
 const buffer = 128
 
 type tree interface {
-	Watch(string, chan<- EventInfo, func(string) bool, ...Event) error
+	Watch(string, chan<- EventInfo, DoNotWatchFn, ...Event) error
 	Stop(chan<- EventInfo)
 	Close() error
 }

--- a/tree_nonrecursive.go
+++ b/tree_nonrecursive.go
@@ -93,7 +93,7 @@ func (t *nonrecursiveTree) internal(rec <-chan EventInfo) {
 			t.rw.Unlock()
 			continue
 		}
-		err := nd.Add(ei.Path()).AddDir(t.recFunc(eset, nil))
+		err := nd.Add(ei.Path()).AddDir(t.recFunc(eset), nil)
 		t.rw.Unlock()
 		if err != nil {
 			dbgprintf("internal(%p) error: %v", rec, err)
@@ -146,7 +146,7 @@ func (t *nonrecursiveTree) watchDel(nd node, c chan<- EventInfo, e Event) eventD
 
 // Watch TODO(rjeczalik)
 func (t *nonrecursiveTree) Watch(path string, c chan<- EventInfo,
-	doNotWatch func(string) bool, events ...Event) error {
+	doNotWatch DoNotWatchFn, events ...Event) error {
 	if c == nil {
 		panic("notify: Watch using nil channel")
 	}
@@ -188,8 +188,8 @@ func (t *nonrecursiveTree) watch(nd node, c chan<- EventInfo, e Event) (err erro
 	return nil
 }
 
-func (t *nonrecursiveTree) recFunc(e Event, doNotWatch func(string) bool) walkFunc {
-	addWatch := func(nd node) (err error) {
+func (t *nonrecursiveTree) recFunc(e Event) walkFunc {
+	return func(nd node) (err error) {
 		switch diff := nd.Watch.Add(t.rec, e|omit|Create); {
 		case diff == none:
 		case diff[1] == 0:
@@ -202,20 +202,11 @@ func (t *nonrecursiveTree) recFunc(e Event, doNotWatch func(string) bool) walkFu
 		}
 		return
 	}
-	if doNotWatch != nil {
-		return func(nd node) (err error) {
-			if doNotWatch(nd.Name) {
-				return errSkip
-			}
-			return addWatch(nd)
-		}
-	}
-	return addWatch
 }
 
 func (t *nonrecursiveTree) watchrec(nd node, c chan<- EventInfo, e Event,
-	doNotWatch func(string) bool) error {
-	var traverse func(walkFunc) error
+	doNotWatch DoNotWatchFn) error {
+	var traverse func(walkFunc, DoNotWatchFn) error
 	// Non-recursive tree listens on Create event for every recursive
 	// watchpoint in order to automagically set a watch for every
 	// created directory.
@@ -236,7 +227,7 @@ func (t *nonrecursiveTree) watchrec(nd node, c chan<- EventInfo, e Event,
 	}
 	// TODO(rjeczalik): account every path that failed to be (re)watched
 	// and retry.
-	if err := traverse(t.recFunc(e, doNotWatch)); err != nil {
+	if err := traverse(t.recFunc(e), doNotWatch); err != nil {
 		return err
 	}
 	t.watchAdd(nd, c, e)

--- a/tree_recursive.go
+++ b/tree_recursive.go
@@ -154,7 +154,7 @@ func (t *recursiveTree) dispatch() {
 
 // Watch TODO(rjeczalik)
 func (t *recursiveTree) Watch(path string, c chan<- EventInfo,
-	doNotWatch func(string) bool, events ...Event) error {
+	_ DoNotWatchFn, events ...Event) error {
 	if c == nil {
 		panic("notify: Watch using nil channel")
 	}
@@ -233,7 +233,7 @@ func (t *recursiveTree) Watch(path string, c chan<- EventInfo,
 		children = append(children, nd)
 		return errSkip
 	}
-	switch must(cur.Walk(fn)); len(children) {
+	switch must(cur.Walk(fn, nil)); len(children) {
 	case 0:
 		// no child watches, cur holds a new watch
 	case 1:
@@ -332,14 +332,14 @@ func (t *recursiveTree) Stop(c chan<- EventInfo) {
 			watchDel(nd, c, all)
 			return nil
 		}
-		err = nonil(err, e, nd.Walk(fn))
+		err = nonil(err, e, nd.Walk(fn, nil))
 		// TODO(rjeczalik): if e != nil store dummy chan in nd.Watch just to
 		// retry un/rewatching next time and/or let the user handle the failure
 		// vie Error event?
 		return errSkip
 	}
 	t.rw.Lock()
-	e := t.root.Walk("", fn) // TODO(rjeczalik): use max root per c
+	e := t.root.Walk("", fn, nil) // TODO(rjeczalik): use max root per c
 	t.rw.Unlock()
 	if e != nil {
 		err = nonil(err, e)


### PR DESCRIPTION
This is to address syncthing/syncthing#4885.

The source of the problem is, that children of a watched directories are loaded with `ioutil.ReadDir` which stats all the contents and returns any occurring error. Ignoring (not watching) happens at a later stage.

Now reading the children is done without ioutil and ignoring happens before stating, thus preventing ignored items to produce an error.

Testing: It builds and notify and syncthing tests pass locally (linux).

This doesn't need to be upstreamed because they didn't want ignoring before (it admittedly isn't complete, but very tailored to our needs).