### PR TITLE
chore: use kqueue on iOS, not FSEvents like on macOS

### DIFF
--- a/event_fsevents.go
+++ b/event_fsevents.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,!kqueue,cgo
+//go:build darwin && !kqueue && cgo && !ios
+// +build darwin,!kqueue,cgo,!ios
 
 package notify
 

--- a/event_kqueue.go
+++ b/event_kqueue.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd
+//go:build (darwin && kqueue) || (darwin && !cgo) || dragonfly || freebsd || netbsd || openbsd || ios
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd ios
 
 package notify
 

--- a/event_trigger.go
+++ b/event_trigger.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris illumos
+//go:build (darwin && kqueue) || (darwin && !cgo) || dragonfly || freebsd || netbsd || openbsd || solaris || illumos || ios
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris illumos ios
 
 package notify
 

--- a/example_fsevents_test.go
+++ b/example_fsevents_test.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,!kqueue,cgo
+//go:build darwin && !kqueue && cgo && !ios
+// +build darwin,!kqueue,cgo,!ios
 
 package notify_test
 

--- a/watcher_fsevents.go
+++ b/watcher_fsevents.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,!kqueue,cgo
+//go:build darwin && !kqueue && cgo && !ios
+// +build darwin,!kqueue,cgo,!ios
 
 package notify
 

--- a/watcher_fsevents_cgo.go
+++ b/watcher_fsevents_cgo.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,!kqueue,cgo
+//go:build darwin && !kqueue && cgo && !ios
+// +build darwin,!kqueue,cgo,!ios
 
 package notify
 

--- a/watcher_fsevents_test.go
+++ b/watcher_fsevents_test.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,!kqueue,cgo
+//go:build darwin && !kqueue && cgo && !ios
+// +build darwin,!kqueue,cgo,!ios
 
 package notify
 

--- a/watcher_kqueue.go
+++ b/watcher_kqueue.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd
+//go:build (darwin && kqueue) || (darwin && !cgo) || dragonfly || freebsd || netbsd || openbsd || ios
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd ios
 
 package notify
 

--- a/watcher_kqueue_test.go
+++ b/watcher_kqueue_test.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd
+//go:build (darwin && kqueue) || (darwin && !cgo) || dragonfly || freebsd || netbsd || openbsd || ios
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd ios
 
 package notify
 

--- a/watcher_notimplemented.go
+++ b/watcher_notimplemented.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build !darwin,!linux,!freebsd,!dragonfly,!netbsd,!openbsd,!windows
-// +build !kqueue,!solaris,!illumos
+//go:build !darwin && !linux && !freebsd && !dragonfly && !netbsd && !openbsd && !windows && !kqueue && !solaris && !illumos
+// +build !darwin,!linux,!freebsd,!dragonfly,!netbsd,!openbsd,!windows,!kqueue,!solaris,!illumos
 
 package notify
 

--- a/watcher_trigger.go
+++ b/watcher_trigger.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris illumos
+//go:build (darwin && kqueue) || (darwin && !cgo) || dragonfly || freebsd || netbsd || openbsd || solaris || illumos || ios
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris illumos ios
 
 // watcher_trigger is used for FEN and kqueue which behave similarly:
 // only files and dirs can be watched directly, but not files inside dirs.

--- a/watcher_trigger_test.go
+++ b/watcher_trigger_test.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris illumos
+//go:build (darwin && kqueue) || (darwin && !cgo) || dragonfly || freebsd || netbsd || openbsd || solaris || illumos || ios
+// +build darwin,kqueue darwin,!cgo dragonfly freebsd netbsd openbsd solaris illumos ios
 
 package notify
 


### PR DESCRIPTION
On macOS, `notify` uses the FSEvents API. This is unfortunately not available on iOS. However before this PR, it would be used due to `darwin` build rule also matching iOS.

This PR ensures that the `kqueue` variant is built for iOS.